### PR TITLE
Simplify docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM ruby:2.6.6
-RUN mkdir /usr/src/gem
-WORKDIR /usr/src/gem
-ADD . /usr/src/gem

--- a/README.md
+++ b/README.md
@@ -206,11 +206,27 @@ The current gem and approach have some limitations:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then,
-run `rake spec` to run the tests. You can also run `bin/console` for an
-interactive prompt that will allow you to experiment.
+This repo contains a docker-compose file that starts Zeebe and can be used for
+local development. Docker and Docker Compose most be installed as prerequisites.
+
+Run the following to start a bash session. Gems will automatically be bundled and
+the environment will have access to a running Zeebe broker:
+
+```bash
+docker-compose run --rm console bash
+```
+
+To run specs using docker-compose run the following command:
+
+```bash
+docker-compose run --rm console rspec
+```
+
+### Install Locally
 
 To install this gem onto your local machine, run `bundle exec rake install`. 
+
+### Create a Release
 
 To release a new version, update the version number in `version.rb`, and then
 run `bundle exec rake release`, which will create a git tag for the version,

--- a/compose/entrypoint.sh
+++ b/compose/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bundle install
+
+exec $*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,29 +8,24 @@ x-environment: &default-environment
   BUNDLE_DISABLE_SHARED_GEMS: "true"
   ZEEBE_ADDRESS: zeebe-bpmn-gateway:26500
 x-service: &default-service
-  build:
-    context: .
+  image: ruby:2.6.6
   volumes:
     - .:/usr/src/gem
+    - ./compose/entrypoint.sh:/tmp/entrypoint.sh
     - bundle-volume:/usr/local/bundle:delegated
     - shared-volume:/usr/src/shared:delegated
   tty: true
   stdin_open: true
 services:
-  zeebe-bpmn-gateway:
-    container_name: zeebe-bpmn-gateway_1
+  zeebe:
     image: camunda/zeebe:0.23.2
-    ports:
-      - "26500:26500"
-      - "9600:9600"
     environment:
       ZEEBE_LOG_LEVEL: debug
     volumes:
       - ./compose/zeebe-hazelcast-exporter.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter.jar
       - ./compose/application.yml:/usr/local/zeebe/config/application.yaml
 
-  zeebe-bpmn-monitor:
-    container_name: zeebe-bpmn-monitor_1
+  monitor:
     image: camunda/zeebe-simple-monitor:0.19.0
     environment:
       - zeebe.client.broker.contactPoint=zeebe-bpmn-gateway:26500
@@ -38,13 +33,14 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - zeebe-bpmn-gateway
+      - zeebe
 
-  zeebe-bpmn-console:
+  console:
     <<: *default-service
-    container_name: zeebe-bpmn-console_1
     environment:
       <<: *default-environment
+    entrypoint: /tmp/entrypoint.sh
     command: bash
+    working_dir: /usr/src/gem
     depends_on:
-      - zeebe-bpmn-gateway
+      - zeebe


### PR DESCRIPTION
## What did we change?

- Removed Dockerfile, use standard ruby 2.6.6 image
- Removed container names and unnecessary external ports from docker-compose
- Add entrypoint script to automatically bundle

## Why are we doing this?

To make it easier to do local development using docker with this repo.

This is pretty slick now. One command can be used to spin up Zeebe and run specs for the repo:

```
docker-compose run --rm console rspec
```

## How was it tested?
- [ ] Specs
- [x] Locally
- [ ] Staging
