### PR TITLE
Use top-level timeout in `activate_job`

### DIFF
--- a/lib/zeebe_bpmn_rspec/activated_job.rb
+++ b/lib/zeebe_bpmn_rspec/activated_job.rb
@@ -19,6 +19,7 @@ module ZeebeBpmnRspec
 
       if validate
         context.instance_eval do
+          expect(job).not_to be_nil, "expected to receive job of type '#{type}' but received none"
           aggregate_failures do
             expect(job.workflowInstanceKey).to eq(workflow_instance_key)
             expect(job.type).to eq(type)

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -69,8 +69,8 @@ module ZeebeBpmnRspec
                                              type: type,
                                              worker: "#{type}-#{SecureRandom.hex}",
                                              maxJobsToActivate: 1,
-                                             timeout: 5000, # TODO: configure
-                                             requestTimeout: 5000
+                                             timeout: 1000,
+                                             requestTimeout: ZeebeBpmnRspec.activate_request_timeout
                                            ))
 
       job = nil

--- a/spec/zeebe_bpmn_rspec/helpers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/helpers_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
         expect(job.headers).to eq("what_to_do" => "nothing")
       end
     end
+
+    it "times out after the globally configured time" do
+      allow(ZeebeBpmnRspec).to receive(:activate_request_timeout).and_return(100) # ms
+      with_workflow_instance("one_task", { input: 1 }) do
+        t1 = Time.now
+        job = activate_job("do_nothing", validate: false)
+        t2 = Time.now
+
+        expect(job.job).to be_nil
+        expect(t2 - t1).to be < 0.5 # much less than the default value of 1 second
+      end
+    end
   end
 
   describe "ActivatedJob#expect_input" do


### PR DESCRIPTION
## What did we change?
* Updated the singular `activate_job` helper to use the same top-level timeout as the plural `activate_jobs` helper.
* Updated the auto validation in `ActivatedJob#initialize` to fail gracefully if `activate_job` did time out.

## Why are we doing this?
* I believe that the Jenkins failures on [this workflows-bpmn PR](https://github.com/ezcater/workflows-bpmn/pull/20) are related to timing out (those specs pass locally on multiple developers' machines), but right now there is no way to override the timeout when using the singular helper.
* Without the additional check in the ActivatedJob validation, the next check on line 24 will raise NoMethodErrors instead of a neat failure.

## How was it tested?
- [X] Specs
- [X] Locally
- [ ] Staging
