### PR TITLE
New gem functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0 (unreleased)
 - Add `ttl_ms` option for `publish_message`.
 - Add `update_retries` method to `ActivatedJob` class.
+- Add `set_variables` helper.
 
 ## v0.3.1
 - Use consistent activate request timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zeebe_bpmn_rspec
 
+## v0.4.0 (unreleased)
+- Add `ttl_ms` option for `publish_message`.
+
 ## v0.3.1
 - Use consistent activate request timeout.
 - Provide a better error when a job is not activated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `ttl_ms` option for `publish_message`.
 - Add `update_retries` method to `ActivatedJob` class.
 - Add `set_variables` helper.
+- Add support for `:fetch_variables` option when activating jobs.
 
 ## v0.3.1
 - Use consistent activate request timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.0 (unreleased)
 - Add `ttl_ms` option for `publish_message`.
+- Add `update_retries` method to `ActivatedJob` class.
 
 ## v0.3.1
 - Use consistent activate request timeout.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,30 @@ It defaults to 5000 milliseconds if unspecified.
 publish_message("message_name", correlation_key: expected_value, ttl_ms: 1000)
 ```
 
+### Set Variables
+
+The `set_variables` method can be used to set variables for a specified
+scope in Zeebe:
+
+```ruby
+# workflow_instance_key is a method that returns the key for the current workflow instance
+set_variables(workflow_instance_key, { foo: "bar" })
+```
+
+An activated job can be used to determine the key for the task that it is associated with:
+
+```ruby
+job = job_with_type("my_type")
+set_variables(job.task_key, { foo: "baz"})
+```
+
+Variables default to being local to the scope on which they are set. This
+can be overridden by specifying the `:local` option:
+
+```ruby
+set_variables(job.task_key, { foo: "baz"}, local: false)
+```
+
 ### Custom Matchers
 
 In addition to the helpers documented above, this gem defines custom RSpec matchers to provide a more typical

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ job = activate_job("my_job")
 job.fail(retries: 1)
 ```
 
+#### Update Retries
+
+The retries for a job can also be modified using the `update_retries` method:
+
+```ruby
+job = activate_job("my_job")
+
+job.update_retries(3)
+```
+
 #### Throw Error
 
 The `and_throw_error` (also aliased as `throw_error`) method can be used to throw an error for a job. The error code is required and an

--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ publish_message("message_name", correlation_key: expected_value,
                 variables: { foo: "bar" })
 ```
 
+The time-to-live (in milliseconds) cna also be specified for a message.
+It defaults to 5000 milliseconds if unspecified.
+
+```ruby
+publish_message("message_name", correlation_key: expected_value, ttl_ms: 1000)
+```
+
 ### Custom Matchers
 
 In addition to the helpers documented above, this gem defines custom RSpec matchers to provide a more typical

--- a/lib/zeebe_bpmn_rspec/activated_job.rb
+++ b/lib/zeebe_bpmn_rspec/activated_job.rb
@@ -36,6 +36,10 @@ module ZeebeBpmnRspec
       job.key
     end
 
+    def retries
+      job.retries
+    end
+
     def to_s
       raw.to_s
     end
@@ -97,6 +101,13 @@ module ZeebeBpmnRspec
                           ))
     end
     alias complete and_complete
+
+    def update_retries(retries = 1)
+      client.update_job_retries(UpdateJobRetriesRequest.new(
+                                  jobKey: job.key,
+                                  retries: retries
+                                ))
+    end
 
     private
 

--- a/lib/zeebe_bpmn_rspec/activated_job.rb
+++ b/lib/zeebe_bpmn_rspec/activated_job.rb
@@ -40,6 +40,10 @@ module ZeebeBpmnRspec
       job.retries
     end
 
+    def task_key
+      job.elementInstanceKey
+    end
+
     def to_s
       raw.to_s
     end

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -129,6 +129,14 @@ module ZeebeBpmnRspec
                                     ))
     end
 
+    def set_variables(key, variables, local: true)
+      _zeebe_client.set_variables(SetVariablesRequest.new(
+                                    elementInstanceKey: key,
+                                    variables: variables.to_json,
+                                    local: local
+                                  ))
+    end
+
     def reset_zeebe!
       @__workflow_instance_key = nil
     end

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -118,12 +118,12 @@ module ZeebeBpmnRspec
       end
     end
 
-    def publish_message(name, correlation_key:, variables: nil)
+    def publish_message(name, correlation_key:, variables: nil, ttl_ms: 5000)
       _zeebe_client.publish_message(PublishMessageRequest.new(
                                       {
                                         name: name,
                                         correlationKey: correlation_key,
-                                        timeToLive: 5000,
+                                        timeToLive: ttl_ms,
                                         variables: variables&.to_json,
                                       }.compact
                                     ))

--- a/lib/zeebe_bpmn_rspec/version.rb
+++ b/lib/zeebe_bpmn_rspec/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZeebeBpmnRspec
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/zeebe_bpmn_rspec/helpers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/helpers_spec.rb
@@ -199,5 +199,13 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
         workflow_complete!
       end
     end
+
+    it "can publish a message with a ttl" do
+      with_workflow_instance("message_receive", expected_message_key: (key = SecureRandom.uuid)) do
+        publish_message("expected_message", correlation_key: key, ttl_ms: 1000)
+
+        workflow_complete!
+      end
+    end
   end
 end

--- a/spec/zeebe_bpmn_rspec/helpers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/helpers_spec.rb
@@ -145,6 +145,23 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
   end
 
+  describe "ActivatedJob#update_retries" do
+    it "can update the retries for a job" do
+      with_workflow_instance("one_task") do
+        job = job_with_type("do_something")
+        job.fail(retries: 1)
+
+        job.update_retries(3)
+
+        new_job = job_with_type("do_something")
+        expect(new_job.retries).to eq(3)
+        new_job.complete
+
+        workflow_complete!
+      end
+    end
+  end
+
   describe "ActivatedJob#and_throw_error" do
     it "can throw an error for a job" do
       with_workflow_instance("one_task") do

--- a/spec/zeebe_bpmn_rspec/matchers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/matchers_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe "Matchers" do # rubocop:disable RSpec/DescribeClass
     expect_job_of_type("do_something").to have_activated.with_variables(start_variables)
   end
 
+  it "can activate a job with specific variables and check them" do
+    expect_job_of_type("do_something", fetch_variables: :a).
+      to have_activated.with_variables("a" => 99)
+  end
+
   it "fails if the variables do not match the expected" do
     expect do
       expect_job_of_type("do_something").to have_activated.with_variables(c: 1)


### PR DESCRIPTION
## What did we change?

The following functionality/support is added:
- set time-to-live when publishing a message
- update retries for a job
- set variables
- specify fetch variables when activating jobs

## Why are we doing this?

I had a use case for setting a shorter TTL on a message.

The other additions are to make the support more complete and to get a better understanding of Zeebe functionality.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
