### PR TITLE
Minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # zeebe_bpmn_rspec
 
+## v0.4.1
+- Allow `with_workflow_instance` to be called without a block.
+- Allow `worker` to be specified when activating a job.
+- Expose `workflow_instance_key` for activated jobs.
+
 ## v0.4.0
 - Add `ttl_ms` option for `publish_message`.
 - Add `update_retries` method to `ActivatedJob` class.

--- a/lib/zeebe_bpmn_rspec/activated_job.rb
+++ b/lib/zeebe_bpmn_rspec/activated_job.rb
@@ -8,7 +8,7 @@ module ZeebeBpmnRspec
   class ActivatedJob
     include ::Zeebe::Client::GatewayProtocol # for direct reference of request classes
 
-    attr_reader :job, :type, :workflow_instance_key
+    attr_reader :job, :type
 
     def initialize(job, type:, workflow_instance_key:, client:, context:, validate:) # rubocop:disable Metrics/ParameterLists
       @job = job
@@ -34,6 +34,10 @@ module ZeebeBpmnRspec
 
     def key
       job.key
+    end
+
+    def workflow_instance_key
+      job.workflowInstanceKey
     end
 
     def retries

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -26,7 +26,7 @@ module ZeebeBpmnRspec
                                                           variables: variables.to_json
                                                         ))
       @__workflow_instance_key = workflow.workflowInstanceKey
-      yield(workflow.workflowInstanceKey)
+      yield(workflow.workflowInstanceKey) if block_given?
     rescue Exception => e # rubocop:disable Lint/RescueException
       # exceptions are rescued to ensure that instances are cancelled
       # any error is re-raised below
@@ -64,10 +64,10 @@ module ZeebeBpmnRspec
       @__workflow_instance_key
     end
 
-    def activate_job(type, fetch_variables: nil, validate: true)
+    def activate_job(type, fetch_variables: nil, validate: true, worker: "#{type}-#{SecureRandom.hex}")
       stream = _zeebe_client.activate_jobs(ActivateJobsRequest.new({
         type: type,
-        worker: "#{type}-#{SecureRandom.hex}",
+        worker: worker,
         maxJobsToActivate: 1,
         timeout: 1000,
         fetchVariable: fetch_variables&.then { |v| Array(v) },

--- a/spec/zeebe_bpmn_rspec/helpers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/helpers_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
       expect(key).to eq(workflow_instance_key)
     end
+
+    it "can start and stop a workflow without requiring a block" do
+      expect do
+        with_workflow_instance("one_task")
+      end.not_to raise_error
+    end
   end
 
   describe "#workflow_complete!" do
@@ -65,6 +71,23 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
         expect(job.variables).to eq("input" => 1)
         expect(job.headers).to eq("what_to_do" => "nothing")
+      end
+    end
+
+    it "can activate a job with a specific worker" do
+      with_workflow_instance("one_task") do
+        worker = "my-worker-#{SecureRandom.hex}"
+        job = activate_job("do_something", worker: worker)
+
+        expect(job.raw.worker).to eq(worker)
+      end
+    end
+
+    it "allows a job to be activated with a nil worker" do
+      with_workflow_instance("one_task") do
+        job = activate_job("do_something", worker: nil, validate: false)
+
+        expect(job.raw).to be_nil
       end
     end
 
@@ -101,6 +124,16 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
         job = activate_job("do_something", fetch_variables: %w(b c))
 
         expect(job).to have_variables("b" => 2, "c" => 3)
+      end
+    end
+  end
+
+  describe "ActivatedJob#workflow_instance_key" do
+    it "exposes the workflow instance key for a job" do
+      with_workflow_instance("one_task") do
+        job = activate_job("do_something")
+
+        expect(job.workflow_instance_key).to eq(workflow_instance_key)
       end
     end
   end


### PR DESCRIPTION
## What did we change?

Some minor changes:
- Allow `with_workflow_instance` to be called without a block.
- Allow `worker` to be specified when activating a job.
- Expose `workflow_instance_key` for activated jobs.

## Why are we doing this?

These are small improvements that would have made things simpler when writing tests for zeebe-monitor.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
