### PR TITLE
Develop and test with Zeebe v0.25.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - image: circleci/ruby:2.6.6
         environment:
           - ZEEBE_ADDRESS: localhost:26500
-      - image: camunda/zeebe:0.23.2
+      - image: camunda/zeebe:0.25.1
     steps:
       - checkout
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ x-service: &default-service
   stdin_open: true
 services:
   zeebe:
-    image: camunda/zeebe:${ZEEBE_VERSION:-0.24.1}
+    image: camunda/zeebe:${ZEEBE_VERSION:-0.25.1}
     environment:
       ZEEBE_LOG_LEVEL: debug
     volumes:
@@ -26,7 +26,7 @@ services:
       - ./compose/application.yml:/usr/local/zeebe/config/application.yaml
 
   monitor:
-    image: camunda/zeebe-simple-monitor:0.19.0
+    image: camunda/zeebe-simple-monitor:0.19.1
     environment:
       - zeebe.client.broker.contactPoint=zeebe:26500
       - zeebe.client.worker.hazelcast.connection=zeebe:5701


### PR DESCRIPTION
## What did we change?

- Develop and test with Zeebe v0.25.1.
- Use the latest Simple Monitor v0.19.1 for development.
- Use the latest [Zeebe Hazelcast Exporter v0.10.0](https://github.com/zeebe-io/zeebe-hazelcast-exporter/releases/tag/0.10.0) for development.

## Why are we doing this?

Getting back up to date with the most recent versions.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
