### PR TITLE
Support Zeebe v1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ jobs:
     parallelism: 1
     working_directory: ~/ezcater
     docker:
-      - image: circleci/ruby:2.7.2
+      - image: circleci/ruby:2.7.3
         environment:
           - ZEEBE_ADDRESS: localhost:26500
-      - image: camunda/zeebe:0.26.1
+      - image: camunda/zeebe:1.0.0
     steps:
       - checkout
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,14 @@
 inherit_gem:
   ezcater_rubocop: conf/rubocop_gem.yml
 
+inherit_mode:
+  merge:
+  - Exclude
+
 RSpec/ExampleLength:
   Enabled: false
 
 AllCops:
   TargetRubyVersion: 2.6
+  Exclude:
+    - 'vendor/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # zeebe_bpmn_rspec
 
+## v1.0.0 (unreleased)
+- Support Zeebe 1.0.0. Method names now use `process` instead of `workflow`
+  to match the renaming in Zeebe. Previous methods are deprecated and will be
+  removed in a future release.
+
 ## v0.5.0 (unreleased)
 - Require Ruby 2.6 or later.
 - Require `worker` to be specified when activating a job. This argument is

--- a/README.md
+++ b/README.md
@@ -41,24 +41,24 @@ The gem adds the following helper methods to RSpec.
 
 The gem also defines [Custom Matchers](#custom-matchers).
 
-### Deploy Workflow
+### Deploy Process
 
-The `deploy_workflow` method requires a path to a BPMN file and deploys it to Zeebe. There is no support for
+The `deploy_process` (previously `deploy_workflow`) method requires a path to a BPMN file and deploys it to Zeebe. There is no support for
 removing a BPMN file once deployed, so this can be done once before the examples that use it.
 
 ```ruby
-before(:all) { deploy_workflow(filepath) }
+before(:all) { deploy_process(filepath) }
 ```
 
-A custom name can also be specified for the workflow:
+A custom name can also be specified for the process:
 
 ```ruby
-before(:all) { deploy_workflow(filepath, "custom_name") }
+before(:all) { deploy_process(filepath, "custom_name") }
 ```
 
-### With Workflow Instance
+### With Process Instance
 
-The `with_workflow_instance` method is used to create an instance for the specified workflow
+The `with_process_instance` (previously `with_workflow_instance`) method is used to create an instance for the specified process
 and then yields a block that can interact with the instance.
 
 This method ensures that an active instance is cancelled at the end of the block.
@@ -67,14 +67,14 @@ For testing BPMN files it is expected that most of the test definition will be w
 call to this method.
 
 ```ruby
-with_workflow_instance("file_basename") do
+with_process_instance("file_basename") do
   ...
 end
 ```
 
 ### Processing Jobs
 
-A single job can be processed for a workflow by calling `activate_job` (previously `process_job`).
+A single job can be processed for a process by calling `activate_job` (previously `process_job`).
 `activate_job` is called with a job type:
 
 ```ruby
@@ -129,8 +129,8 @@ activate_job("my_job").
   expect_input(user_id: 123).
   and_complete
 
-# Jobs can be completed with data that is merged with variables in the workflow
-project_job("my_job").
+# Jobs can be completed with data that is merged with variables in the process
+activate_job("my_job").
   and_complete(status: "ACTIVATED")
 ```
 
@@ -198,17 +198,17 @@ The maximum number of jobs to return can be specified:
 jobs = activate_jobs("my_job", max_jobs: 2).to_a
 ```
 
-### Workflow Complete
+### Process Complete
 
-The `workflow_complete!` method can be used to assert that the current workflow is complete at the end of a
-test. This is implemented by cancelling the workflow and checking for an error that it is already
+The `process_complete!` (previously `workflow_complete!`) method can be used to assert that the current process is complete at the end of a
+test. This is implemented by cancelling the process and checking for an error that it is already
 complete.
 
 ```ruby
-with_workflow_instance("file_basename") do
+with_process_instance("file_basename") do
   ...
 
-  workflow_complete!
+  process_complete!
 end
 ```
 
@@ -242,8 +242,8 @@ The `set_variables` method can be used to set variables for a specified
 scope in Zeebe:
 
 ```ruby
-# workflow_instance_key is a method that returns the key for the current workflow instance
-set_variables(workflow_instance_key, { foo: "bar" })
+# process_instance_key is a method that returns the key for the current process instance
+set_variables(process_instance_key, { foo: "bar" })
 ```
 
 An activated job can be used to determine the key for the task that it is associated with:
@@ -370,7 +370,7 @@ to specify a short duration.
 
 The current gem and approach have some limitations:
 
-1. You can interact with only one workflow at a time.
+1. You can interact with only one process at a time.
 
 ## Development
 

--- a/docker-compose.simple-monitor.yml
+++ b/docker-compose.simple-monitor.yml
@@ -1,0 +1,17 @@
+version: "3.4"
+
+services:
+  zeebe:
+    volumes:
+      - ./compose/zeebe-hazelcast-exporter.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter.jar
+      - ./compose/application.yml:/usr/local/zeebe/config/application.yaml
+
+  monitor:
+    image: camunda/zeebe-simple-monitor:0.19.1
+    environment:
+      - zeebe.client.broker.contactPoint=zeebe:26500
+      - zeebe.client.worker.hazelcast.connection=zeebe:5701
+    ports:
+      - "8082:8082"
+    depends_on:
+      - zeebe

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-environment: &default-environment
   BUNDLE_DISABLE_SHARED_GEMS: "true"
   ZEEBE_ADDRESS: zeebe:26500
 x-service: &default-service
-  image: ruby:2.7.2
+  image: ruby:2.7.3
   volumes:
     - .:/usr/src/gem
     - ./compose/entrypoint.sh:/tmp/entrypoint.sh
@@ -18,22 +18,9 @@ x-service: &default-service
   stdin_open: true
 services:
   zeebe:
-    image: camunda/zeebe:${ZEEBE_VERSION:-0.26.1}
+    image: camunda/zeebe:${ZEEBE_VERSION:-1.0.0}
     environment:
       ZEEBE_LOG_LEVEL: debug
-    volumes:
-      - ./compose/zeebe-hazelcast-exporter.jar:/usr/local/zeebe/exporters/zeebe-hazelcast-exporter.jar
-      - ./compose/application.yml:/usr/local/zeebe/config/application.yaml
-
-  monitor:
-    image: camunda/zeebe-simple-monitor:0.19.1
-    environment:
-      - zeebe.client.broker.contactPoint=zeebe:26500
-      - zeebe.client.worker.hazelcast.connection=zeebe:5701
-    ports:
-      - "8082:8082"
-    depends_on:
-      - zeebe
 
   console:
     <<: *default-service

--- a/lib/zeebe_bpmn_rspec.rb
+++ b/lib/zeebe_bpmn_rspec.rb
@@ -3,6 +3,7 @@
 require "active_support"
 require "rspec"
 require "zeebe/client"
+require "zeebe_bpmn_rspec/deprecate_workflow_alias"
 require "zeebe_bpmn_rspec/helpers"
 require "zeebe_bpmn_rspec/version"
 require "zeebe_bpmn_rspec/matchers/have_activated"

--- a/lib/zeebe_bpmn_rspec/activated_job.rb
+++ b/lib/zeebe_bpmn_rspec/activated_job.rb
@@ -6,13 +6,14 @@ require "json"
 module ZeebeBpmnRspec
   class ActivatedJob
     include ::Zeebe::Client::GatewayProtocol # for direct reference of request classes
+    extend DeprecateWorkflowAlias
 
     attr_reader :job, :type
 
-    def initialize(job, type:, workflow_instance_key:, client:, context:, validate:) # rubocop:disable Metrics/ParameterLists
+    def initialize(job, type:, process_instance_key:, client:, context:, validate:) # rubocop:disable Metrics/ParameterLists
       @job = job
       @type = type
-      @workflow_instance_key = workflow_instance_key
+      @process_instance_key = process_instance_key
       @client = client
       @context = context
 
@@ -20,7 +21,7 @@ module ZeebeBpmnRspec
         context.instance_eval do
           expect(job).not_to be_nil, "expected to receive job of type '#{type}' but received none"
           aggregate_failures do
-            expect(job.workflowInstanceKey).to eq(workflow_instance_key)
+            expect(job.processInstanceKey).to eq(process_instance_key)
             expect(job.type).to eq(type)
           end
         end
@@ -35,9 +36,10 @@ module ZeebeBpmnRspec
       job.key
     end
 
-    def workflow_instance_key
-      job.workflowInstanceKey
+    def process_instance_key
+      job.processInstanceKey
     end
+    deprecate_workflow_alias :workflow_instance_key, :process_instance_key
 
     def retries
       job.retries

--- a/lib/zeebe_bpmn_rspec/deprecate_workflow_alias.rb
+++ b/lib/zeebe_bpmn_rspec/deprecate_workflow_alias.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "active_support/deprecation"
+
+module ZeebeBpmnRspec
+  module DeprecateWorkflowAlias
+    WorkflowDeprecation = ActiveSupport::Deprecation.new("v2.0", "ZeebeBpmnRspec")
+
+    def deprecate_workflow_alias(deprecated_name, new_name)
+      alias_method deprecated_name, new_name
+      deprecate deprecated_name => new_name, deprecator: WorkflowDeprecation
+    end
+  end
+end

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -6,38 +6,39 @@ require "zeebe_bpmn_rspec/activated_job"
 module ZeebeBpmnRspec
   module Helpers # rubocop:disable Metrics/ModuleLength
     include ::Zeebe::Client::GatewayProtocol # for direct reference of request classes
+    extend DeprecateWorkflowAlias
 
-    def deploy_workflow(path, name = nil)
-      _zeebe_client.deploy_workflow(DeployWorkflowRequest.new(
-                                      workflows: [WorkflowRequestObject.new(
-                                        name: (name && "#{name}.bpmn") || File.basename(path),
-                                        type: WorkflowRequestObject::ResourceType::FILE,
-                                        definition: File.read(path)
-                                      )]
-                                    ))
+    def deploy_process(path, name = nil)
+      _zeebe_client.deploy_process(DeployProcessRequest.new(
+                                     processes: [ProcessRequestObject.new(
+                                       name: (name && "#{name}.bpmn") || File.basename(path),
+                                       definition: File.read(path)
+                                     )]
+                                   ))
     rescue StandardError => e
-      raise "Failed to deploy workflow: #{e}"
+      raise "Failed to deploy precess: #{e}"
     end
+    deprecate_workflow_alias :deploy_workflow, :deploy_process
 
-    def with_workflow_instance(name, variables = {})
+    def with_process_instance(name, variables = {})
       system_error = nil
-      workflow = _zeebe_client.create_workflow_instance(CreateWorkflowInstanceRequest.new(
-                                                          bpmnProcessId: name,
-                                                          version: -1, # always latest
-                                                          variables: variables.to_json
-                                                        ))
-      @__workflow_instance_key = workflow.workflowInstanceKey
-      yield(workflow.workflowInstanceKey) if block_given?
+      process = _zeebe_client.create_process_instance(CreateProcessInstanceRequest.new(
+                                                        bpmnProcessId: name,
+                                                        version: -1, # always latest
+                                                        variables: variables.to_json
+                                                      ))
+      @__process_instance_key = process.processInstanceKey
+      yield(process.processInstanceKey) if block_given?
     rescue Exception => e # rubocop:disable Lint/RescueException
       # exceptions are rescued to ensure that instances are cancelled
       # any error is re-raised below
       system_error = e
     ensure
-      if workflow&.workflowInstanceKey
+      if process&.processInstanceKey
         begin
-          _zeebe_client.cancel_workflow_instance(CancelWorkflowInstanceRequest.new(
-                                                   workflowInstanceKey: workflow.workflowInstanceKey
-                                                 ))
+          _zeebe_client.cancel_process_instance(CancelProcessInstanceRequest.new(
+                                                  processInstanceKey: process.processInstanceKey
+                                                ))
         rescue GRPC::NotFound => _e
           # expected
         rescue StandardError => _e
@@ -46,24 +47,27 @@ module ZeebeBpmnRspec
       end
       raise system_error if system_error
     end
+    deprecate_workflow_alias :with_workflow_instance, :with_process_instance
 
-    def workflow_complete!
+    def process_complete!(wait_seconds: 0.25)
       error = nil
-      sleep 0.25 # TODO: configurable?
+      sleep(wait_seconds)
       begin
-        _zeebe_client.cancel_workflow_instance(CancelWorkflowInstanceRequest.new(
-                                                 workflowInstanceKey: workflow_instance_key
-                                               ))
+        _zeebe_client.cancel_process_instance(CancelProcessInstanceRequest.new(
+                                                processInstanceKey: process_instance_key
+                                              ))
       rescue GRPC::NotFound => e
         error = e
       end
 
-      raise "Expected workflow instance #{workflow_instance_key} to be complete" if error.nil?
+      raise "Expected process instance #{process_instance_key} to be complete" if error.nil?
     end
+    deprecate_workflow_alias :workflow_complete!, :process_complete!
 
-    def workflow_instance_key
-      @__workflow_instance_key
+    def process_instance_key
+      @__process_instance_key
     end
+    deprecate_workflow_alias :workflow_instance_key, :process_instance_key
 
     def activate_job(type, fetch_variables: nil, validate: true, worker: "#{type}-#{SecureRandom.hex}")
       raise ArgumentError.new("'worker' cannot be blank") if worker.blank?
@@ -83,13 +87,13 @@ module ZeebeBpmnRspec
 
       ActivatedJob.new(job,
                        type: type,
-                       workflow_instance_key: workflow_instance_key,
+                       process_instance_key: process_instance_key,
                        client: _zeebe_client,
                        context: self,
                        validate: validate)
     end
     alias process_job activate_job
-    # TODO: deprecate process_job
+    deprecate process_job: :activate_job
 
     def job_with_type(type, fetch_variables: nil)
       activate_job(type, fetch_variables: fetch_variables, validate: false)
@@ -114,7 +118,7 @@ module ZeebeBpmnRspec
           response.jobs.each do |job|
             yielder << ActivatedJob.new(job,
                                         type: type,
-                                        workflow_instance_key: workflow_instance_key,
+                                        process_instance_key: process_instance_key,
                                         client: _zeebe_client,
                                         context: self,
                                         validate: true)
@@ -143,7 +147,7 @@ module ZeebeBpmnRspec
     end
 
     def reset_zeebe!
-      @__workflow_instance_key = nil
+      @__process_instance_key = nil
     end
 
     private

--- a/spec/zeebe_bpmn_rspec/helpers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/helpers_spec.rb
@@ -9,15 +9,41 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
   let(:bpmn_name) { "one_task" }
   let(:deploy) { true }
 
-  before { deploy_workflow(path) if deploy }
+  before { deploy_process(path) if deploy }
 
-  describe "#deploy_workflow" do
+  describe "#deploy_process" do
+    let(:deploy) { false }
+
+    it "can deploy a process" do
+      response = deploy_process(path)
+
+      process = response.processes.find do |p|
+        p.resourceName == "#{bpmn_name}.bpmn"
+      end
+      expect(process).not_to be_nil
+    end
+
+    context "when a name is specified" do
+      let(:name) { SecureRandom.hex }
+
+      it "deploys the process with that name" do
+        response = deploy_process(path, name)
+
+        process = response.processes.find do |p|
+          p.resourceName == "#{name}.bpmn"
+        end
+        expect(process).not_to be_nil
+      end
+    end
+  end
+
+  describe "#deploy_workflow", :deprecated do
     let(:deploy) { false }
 
     it "can deploy a workflow" do
       response = deploy_workflow(path)
 
-      workflow = response.workflows.find do |wf|
+      workflow = response.processes.find do |wf|
         wf.resourceName == "#{bpmn_name}.bpmn"
       end
       expect(workflow).not_to be_nil
@@ -29,7 +55,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
       it "deploys the workflow with that name" do
         response = deploy_workflow(path, name)
 
-        workflow = response.workflows.find do |wf|
+        workflow = response.processes.find do |wf|
           wf.resourceName == "#{name}.bpmn"
         end
         expect(workflow).not_to be_nil
@@ -37,7 +63,24 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
   end
 
-  describe "#with_workflow_instance" do
+  describe "#with_process_instance" do
+    it "can run a process instance" do
+      key = nil
+      with_process_instance("one_task") do |process_instance_key|
+        key = process_instance_key
+      end
+
+      expect(key).to eq(process_instance_key)
+    end
+
+    it "can start and stop a process without requiring a block" do
+      expect do
+        with_process_instance("one_task")
+      end.not_to raise_error
+    end
+  end
+
+  describe "#with_workflow_instance", :deprecated do
     it "can run a workflow instance" do
       key = nil
       with_workflow_instance("one_task") do |workflow_instance_key|
@@ -54,7 +97,17 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
   end
 
-  describe "#workflow_complete!" do
+  describe "#process_complete!" do
+    it "can assert that a process is complete" do
+      with_process_instance("one_task") do
+        activate_job("do_something").and_complete
+
+        process_complete!
+      end
+    end
+  end
+
+  describe "#workflow_complete!", :deprecated do
     it "can assert that a workflow is complete" do
       with_workflow_instance("one_task") do
         activate_job("do_something").and_complete
@@ -66,7 +119,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
   describe "#activate_job" do
     it "can activate a job" do
-      with_workflow_instance("one_task", { input: 1 }) do
+      with_process_instance("one_task", { input: 1 }) do
         job = activate_job("do_something")
 
         expect(job.variables).to eq("input" => 1)
@@ -75,7 +128,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
 
     it "can activate a job with a specific worker" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         worker = "my-worker-#{SecureRandom.hex}"
         job = activate_job("do_something", worker: worker)
 
@@ -85,7 +138,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
     it "does not allow a job to be activated with a nil worker" do
       expect do
-        with_workflow_instance("one_task") do
+        with_process_instance("one_task") do
           job = activate_job("do_something", worker: nil, validate: false)
 
           expect(job.raw).to be_nil
@@ -95,7 +148,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
     it "does not allow a job to be activated with a blank worker" do
       expect do
-        with_workflow_instance("one_task") do
+        with_process_instance("one_task") do
           job = activate_job("do_something", worker: "", validate: false)
 
           expect(job.raw).to be_nil
@@ -105,7 +158,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
     it "times out after the globally configured time" do
       allow(ZeebeBpmnRspec).to receive(:activate_request_timeout).and_return(100) # ms
-      with_workflow_instance("one_task", { input: 1 }) do
+      with_process_instance("one_task", { input: 1 }) do
         t1 = Time.now
         job = activate_job("do_nothing", validate: false)
         t2 = Time.now
@@ -116,7 +169,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
 
     it "can activate a job with specific variables" do
-      with_workflow_instance("one_task", { a: 1, b: 2 }) do
+      with_process_instance("one_task", { a: 1, b: 2 }) do
         job = activate_job("do_something", fetch_variables: :a)
 
         expect(job).to have_variables("a" => 1)
@@ -124,7 +177,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
 
     it "can activate a job with a missing variable" do
-      with_workflow_instance("one_task", { a: 1, b: 2 }) do
+      with_process_instance("one_task", { a: 1, b: 2 }) do
         job = activate_job("do_something", fetch_variables: "c")
 
         expect(job).to have_variables({})
@@ -132,7 +185,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
 
     it "can activate a job with multiple variables" do
-      with_workflow_instance("one_task", { a: 1, b: 2, c: 3 }) do
+      with_process_instance("one_task", { a: 1, b: 2, c: 3 }) do
         job = activate_job("do_something", fetch_variables: %w(b c))
 
         expect(job).to have_variables("b" => 2, "c" => 3)
@@ -140,7 +193,17 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
   end
 
-  describe "ActivatedJob#workflow_instance_key" do
+  describe "ActivatedJob#process_instance_key" do
+    it "exposes the process instance key for a job" do
+      with_process_instance("one_task") do
+        job = activate_job("do_something")
+
+        expect(job.process_instance_key).to eq(process_instance_key)
+      end
+    end
+  end
+
+  describe "ActivatedJob#workflow_instance_key", :deprecated do
     it "exposes the workflow instance key for a job" do
       with_workflow_instance("one_task") do
         job = activate_job("do_something")
@@ -152,7 +215,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
   describe "ActivatedJob#expect_input" do
     it "can check the variables for a job" do
-      with_workflow_instance("one_task", { a: 99, b: "c" }) do
+      with_process_instance("one_task", { a: 99, b: "c" }) do
         activate_job("do_something").expect_input(a: 99, b: "c")
       end
     end
@@ -160,7 +223,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
   describe "ActivatedJob#expect_headers" do
     it "can check the headers for a job" do
-      with_workflow_instance("one_task", { a: 99, b: "c" }) do
+      with_process_instance("one_task", { a: 99, b: "c" }) do
         activate_job("do_something").expect_headers(what_to_do: "nothing")
       end
     end
@@ -168,10 +231,10 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
   describe "ActivatedJob#and_complete" do
     it "can complete a job" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         activate_job("do_something").and_complete
 
-        workflow_complete!
+        process_complete!
       end
     end
 
@@ -179,7 +242,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
       let(:bpmn_name) { :two_tasks }
 
       it "can complete a job with new variables" do
-        with_workflow_instance("two_tasks") do
+        with_process_instance("two_tasks") do
           activate_job("do_something").
             and_complete(return: (value = SecureRandom.hex))
 
@@ -192,31 +255,31 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
   describe "ActivatedJob#and_fail" do
     it "can fail a job" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         activate_job("do_something").
           and_fail(retries: 1)
 
         activate_job("do_something").and_complete
 
-        workflow_complete!
+        process_complete!
       end
     end
 
     it "can fail a job with a message" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         activate_job("do_something").
           and_fail("foobar", retries: 1)
 
         activate_job("do_something").and_complete
 
-        workflow_complete!
+        process_complete!
       end
     end
   end
 
   describe "ActivatedJob#update_retries" do
     it "can update the retries for a job" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         job = job_with_type("do_something")
         job.fail(retries: 1)
 
@@ -226,14 +289,14 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
         expect(new_job.retries).to eq(3)
         new_job.complete
 
-        workflow_complete!
+        process_complete!
       end
     end
   end
 
   describe "ActivatedJob#and_throw_error" do
     it "can throw an error for a job" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         job = activate_job("do_something")
 
         job.throw_error("ERROR_BOOM")
@@ -246,7 +309,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     end
 
     it "can throw an error for a job with an error message" do
-      with_workflow_instance("one_task") do
+      with_process_instance("one_task") do
         activate_job("do_something").
           and_throw_error("ERROR_BOOM", "chickaboom")
       end
@@ -257,7 +320,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     let(:bpmn_name) { "parallel_tasks" }
 
     it "can activate multiple jobs" do
-      with_workflow_instance("parallel_tasks") do
+      with_process_instance("parallel_tasks") do
         activate_job("do_something").and_complete
 
         jobs = activate_jobs("parallel", max_jobs: 2).to_a
@@ -270,12 +333,12 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
 
         jobs.map(&:complete)
 
-        workflow_complete!
+        process_complete!
       end
     end
 
     it "can activate jobs with specific variables" do
-      with_workflow_instance("parallel_tasks", { a: 1, b: 2, c: 3 }) do
+      with_process_instance("parallel_tasks", { a: 1, b: 2, c: 3 }) do
         activate_job("do_something").and_complete
 
         jobs = activate_jobs("parallel", fetch_variables: %i(a b), max_jobs: 2).to_a
@@ -289,31 +352,31 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
     let(:bpmn_name) { :message_receive }
 
     it "can publish a message" do
-      with_workflow_instance("message_receive", expected_message_key: (key = SecureRandom.uuid)) do
+      with_process_instance("message_receive", expected_message_key: (key = SecureRandom.uuid)) do
         publish_message("expected_message", correlation_key: key)
 
-        workflow_complete!
+        process_complete!
       end
     end
 
     it "can publish a message with a ttl" do
-      with_workflow_instance("message_receive", expected_message_key: (key = SecureRandom.uuid)) do
+      with_process_instance("message_receive", expected_message_key: (key = SecureRandom.uuid)) do
         publish_message("expected_message", correlation_key: key, ttl_ms: 1000)
 
-        workflow_complete!
+        process_complete!
       end
     end
   end
 
   describe "#set_variables" do
-    it "sets variables for a workflow" do
-      with_workflow_instance("one_task", var: "initial") do
-        set_variables(workflow_instance_key, { var: "updated", new: 1 })
+    it "sets variables for a process" do
+      with_process_instance("one_task", var: "initial") do
+        set_variables(process_instance_key, { var: "updated", new: 1 })
 
         expect(job_with_type("do_something")).to have_activated.
           with_variables(var: "updated", new: 1).and_complete
 
-        workflow_complete!
+        process_complete!
       end
     end
 
@@ -321,7 +384,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
       let(:bpmn_name) { "two_tasks" }
 
       it "can set variables for a task" do
-        with_workflow_instance(bpmn_name, var: "initial") do
+        with_process_instance(bpmn_name, var: "initial") do
           job = job_with_type("do_something")
           job.fail(retries: 1)
 
@@ -333,12 +396,12 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
           expect(job_with_type("next_step")).to have_activated.
             with_variables(var: "initial").and_complete
 
-          workflow_complete!
+          process_complete!
         end
       end
 
       it "can set variables with non-local scope" do
-        with_workflow_instance(bpmn_name, var: "initial") do
+        with_process_instance(bpmn_name, var: "initial") do
           job = job_with_type("do_something")
           job.fail(retries: 1)
 
@@ -350,7 +413,7 @@ RSpec.describe ZeebeBpmnRspec::Helpers do
           expect(job_with_type("next_step")).to have_activated.
             with_variables(var: "updated", new: 1).and_complete
 
-          workflow_complete!
+          process_complete!
         end
       end
     end

--- a/spec/zeebe_bpmn_rspec/matchers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/matchers_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Matchers" do # rubocop:disable RSpec/DescribeClass
   let(:start_variables) { { a: 99, b: "c" } }
 
   around do |example|
-    deploy_workflow(path)
-    with_workflow_instance(bpmn_name, start_variables) do
+    deploy_process(path)
+    with_process_instance(bpmn_name, start_variables) do
       example.run
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe "Matchers" do # rubocop:disable RSpec/DescribeClass
   it "can complete a job" do
     expect_job_of_type("do_something").to have_activated.and_complete
 
-    workflow_complete!
+    process_complete!
   end
 
   context "when new variables are specified" do

--- a/zeebe_bpmn_rspec.gemspec
+++ b/zeebe_bpmn_rspec.gemspec
@@ -52,5 +52,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "rspec", "~> 3.4"
-  spec.add_runtime_dependency "zeebe-client"
+  spec.add_runtime_dependency "zeebe-client", "~> 0.14.0"
 end


### PR DESCRIPTION
## What did we change?

Updated this gem to support the Zeebe v1.0.0 gateway protocol.

## Why are we doing this?

Eventually this gem will need to support the new gateway protocol. Methods in this gem were renamed, but aliases were added for the old names.

I'd suggest releasing this as v1.0 since it requires Zeebe v1.0.0 which itself is a breaking change. Then eventually remove the deprecated aliases as a future v2.0 release.

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
