### PR TITLE
Relax zeebe-client dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zeebe_bpmn_rspec
 
+## v1.0.1
+- Fix dependency issue preventing use of zeebe-client versions 0.15 or above.
+
 ## v1.0.0
 - Support Zeebe 1.0.0. Method names now use `process` instead of `workflow`
   to match the renaming in Zeebe. Previous methods are deprecated and will be

--- a/lib/zeebe_bpmn_rspec/version.rb
+++ b/lib/zeebe_bpmn_rspec/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZeebeBpmnRspec
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/zeebe_bpmn_rspec.gemspec
+++ b/zeebe_bpmn_rspec.gemspec
@@ -52,5 +52,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "rspec", "~> 3.4"
-  spec.add_runtime_dependency "zeebe-client", "~> 0.14.0"
+  spec.add_runtime_dependency "zeebe-client", "~> 0.14"
 end


### PR DESCRIPTION
## What did we change?
Relaxed the zeebe-client dependency from `~> 0.14.0` to `~> 0.14`.

## Why are we doing this?
So that zeebe-client versions 0.15 and above can be used with this gem.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
