### PR TITLE
Support jobs from called activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # zeebe_bpmn_rspec
 
+## unpublished
+- Add `called` option for `activate_job`.
+- Update the validation assertions in `activate_job` to have more helpful error messages.
+
 ## v1.0.1
 - Fix dependency issue preventing use of zeebe-client versions 0.15 or above.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ activate_job("my_job")
 The call to `activate_job` returns a `ActivatedJob` object that provides a fluent interface to chain
 additional expectations and responses onto the job.
 
+#### Activating Jobs from Called Activities
+
+If a job was created by a called activity, its processInstanceKey won't match the parent process.
+To activate a called job without failing the processInstanceKey check, you can set the `called`
+argument to `true`:
+
+```ruby
+activate_job("my_job", called: true)
+```
+
 #### Expect Input
 
 To check the input variables that are passed to the job add `.expect_input`:

--- a/lib/zeebe_bpmn_rspec/activated_job.rb
+++ b/lib/zeebe_bpmn_rspec/activated_job.rb
@@ -10,7 +10,7 @@ module ZeebeBpmnRspec
 
     attr_reader :job, :type
 
-    def initialize(job, type:, process_instance_key:, client:, context:, validate:) # rubocop:disable Metrics/ParameterLists
+    def initialize(job, type:, process_instance_key:, client:, context:, validate:, called: false) # rubocop:disable Metrics/ParameterLists
       @job = job
       @type = type
       @process_instance_key = process_instance_key
@@ -21,8 +21,13 @@ module ZeebeBpmnRspec
         context.instance_eval do
           expect(job).not_to be_nil, "expected to receive job of type '#{type}' but received none"
           aggregate_failures do
-            expect(job.processInstanceKey).to eq(process_instance_key)
-            expect(job.type).to eq(type)
+            unless called
+              expect(job.processInstanceKey).
+                to eq(process_instance_key),
+                   "expected the job's processInstanceKey ('#{job.processInstanceKey}') to match "\
+                   "the process_instance_key ('#{process_instance_key}')"
+            end
+            expect(job.type).to eq(type), "expected job's type ('#{job.type}') to match the expected type ('#{type}')"
           end
         end
       end

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -69,7 +69,7 @@ module ZeebeBpmnRspec
     end
     deprecate_workflow_alias :workflow_instance_key, :process_instance_key
 
-    def activate_job(type, fetch_variables: nil, validate: true, worker: "#{type}-#{SecureRandom.hex}")
+    def activate_job(type, fetch_variables: nil, validate: true, called: false, worker: "#{type}-#{SecureRandom.hex}")
       raise ArgumentError.new("'worker' cannot be blank") if worker.blank?
 
       stream = _zeebe_client.activate_jobs(ActivateJobsRequest.new({
@@ -88,6 +88,7 @@ module ZeebeBpmnRspec
       ActivatedJob.new(job,
                        type: type,
                        process_instance_key: process_instance_key,
+                       called: called,
                        client: _zeebe_client,
                        context: self,
                        validate: validate)


### PR DESCRIPTION
## What did we change?
Support jobs from called activities:
<img width="745" alt="called_activity" src="https://user-images.githubusercontent.com/832755/156900120-d2721b78-618a-417c-a208-accf3f4eeb49.png">

I also updated the error messages for when the processInstanceKey doesn't match. Previously the error looked like:

```
     Failure/Error:
       activate_job("notify_role").
         and_complete(task_id: task_id)

       expected: 2251799813686578
            got: 2251799813686595

       (compared using ==)
```

Now it looks like:

```
     Failure/Error:
       activate_job("notify_role").
         and_complete(task_id: task_id)

       expected the job's processInstanceKey ('2251799813686630') to match the process_instance_key ('2251799813686613')
```

## Why are we doing this?
When a bpmn uses a "call activity" type, the processInstanceKey won't match the parent's processInstanceKey. This causes the `activate_job` helper to fail.

This adds an argument to activate_job to indicate that the job was created by a called activity.

Another workaround would be to set `validate: false`, but that would also prevent other helpful validations, like ensuring the job's type is correct.

Feedback on the argument name welcome, I'm happy to change it from "called" to something else if anyone has a better suggestion.

## How was it tested?
- [ ] Specs
- [x] Locally
- [ ] Staging
