### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @ezcater/oms-workflows @ezcater/oms
+
+.github/settings.yml @ezcater/admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @ezcater/oms-workflows @ezcater/oms
-
-.github/settings.yml @ezcater/admins


### PR DESCRIPTION
## What did we change?
Add a CODEOWNERS file

Normally we also include the following lines in our CODEOWNERS files, but I intentionally omitted `@ezcater/devex` on Docker-related files because this library isn't a part of Tilt:

```
# devex wants to be notified of changes to Dockerfiles and docker-compose.yaml
# so we can be sure to integrate them with eztilt, if necessary
Dockerfile*                   @ezcater/devex
docker-compose.yml            @ezcater/devex
```

I added both @ezcater/oms and @ezcater/oms-workflows; let me know if that should be changed.

## Why are we doing this?
So the owner of this library is clear, and we're alerted as reviewers on PRs.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
