### PR TITLE
Bump up rake to be version ~> 13.0 (a dev dependency)

### DIFF
--- a/zeebe_bpmn_rspec.gemspec
+++ b/zeebe_bpmn_rspec.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "ezcater_rubocop", "2.0.0"
   spec.add_development_dependency "overcommit"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "simplecov", "< 0.18"
 


### PR DESCRIPTION
## What did we change?
Bump up rake to be version ~> 13.0 (a dev dependency)

## Why are we doing this?
To address [the vulnerability reported by dependabot here](https://github.com/ezcater/zeebe_bpmn_rspec/security/dependabot/1).

I don't think this vulnerability is exploitable due to this being a dev dependency in a gem w/o any running services, but it's good to patch.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
