### PR TITLE
Enable trusted-publishing for releasing to RubyGems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/ezcater
     docker:
-      - image: circleci/ruby:2.7.3
+      - image: cimg/ruby:3.2.8
         environment:
           - ZEEBE_ADDRESS: localhost:26500
       - image: camunda/zeebe:1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release Gem
+on: workflow_dispatch
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,10 +5,13 @@ inherit_mode:
   merge:
   - Exclude
 
+plugins:
+  - rubocop-capybara
+
 RSpec/ExampleLength:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.2
   Exclude:
     - 'vendor/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zeebe_bpmn_rspec
 
+## v x.x.x (Unreleased)
+- Drop support for Ruby < 3.2
+
 ## v1.0.1
 - Fix dependency issue preventing use of zeebe-client versions 0.15 or above.
 

--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 ### Create a Release
 
-To release a new version, update the version number in `version.rb`, and then
-run `bundle exec rake release`, which will create a git tag for the version,
-push git commits and tags, and push the `.gem` file to
-[rubygems.org](https://rubygems.org).
+To release a new version, update the version number in `version.rb`, merge your PR to
+`main`, and then manually run the "Release Gem" GitHub Action, which will create a
+git tag for the version, push git commits and tags, and push the `.gem` file
+to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/lib/zeebe_bpmn_rspec/helpers.rb
+++ b/lib/zeebe_bpmn_rspec/helpers.rb
@@ -70,7 +70,7 @@ module ZeebeBpmnRspec
     deprecate_workflow_alias :workflow_instance_key, :process_instance_key
 
     def activate_job(type, fetch_variables: nil, validate: true, worker: "#{type}-#{SecureRandom.hex}")
-      raise ArgumentError.new("'worker' cannot be blank") if worker.blank?
+      raise ArgumentError.new("'worker' cannot be blank") if worker.blank? # rubocop:todo Ezcater/RequireCustomError
 
       stream = _zeebe_client.activate_jobs(ActivateJobsRequest.new({
         type: type,

--- a/lib/zeebe_bpmn_rspec/matchers/have_activated.rb
+++ b/lib/zeebe_bpmn_rspec/matchers/have_activated.rb
@@ -20,8 +20,10 @@ RSpec::Matchers.define :have_activated do
     begin
       aggregate_failures "activated job#{of_type(job)}" do
         unless job.is_a?(ZeebeBpmnRspec::ActivatedJob)
+          # rubocop:todo Ezcater/RequireCustomError
           raise ArgumentError.new("expectation target must be a "\
                                   "#{ZeebeBpmnRspec::ActivatedJob.name}, got #{job.inspect}")
+          # rubocop:enable Ezcater/RequireCustomError
         end
 
         if job.raw.nil?

--- a/spec/zeebe_bpmn_rspec/matchers_spec.rb
+++ b/spec/zeebe_bpmn_rspec/matchers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Matchers" do # rubocop:disable RSpec/DescribeClass
+RSpec.describe "Matchers" do
   let(:path) { File.join(__dir__, "../fixtures/#{bpmn_name}.bpmn") }
   let(:bpmn_name) { "one_task" }
   let(:start_variables) { { a: 99, b: "c" } }

--- a/zeebe_bpmn_rspec.gemspec
+++ b/zeebe_bpmn_rspec.gemspec
@@ -41,10 +41,10 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.2"
 
-  spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "ezcater_rubocop", "2.0.0"
+  spec.add_development_dependency "bundler", "~> 2.6"
+  spec.add_development_dependency "ezcater_rubocop", "~> 9.0.0"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"


### PR DESCRIPTION
## What did we change?
Setup a GitHub Action that uses the RubyGems [trusted publishing](https://guides.rubygems.org/trusted-publishing/) feature to  publish the gem without requiring long-lived secrets. A trusted publisher has already been added on the RubyGems side for this gem.

## Why are we doing this?
To [reduce the supply chain risk](https://ezcater.atlassian.net/wiki/spaces/TRUST/pages/5259591681/Mitigating+Supply+Chain+Risk+Centralizing+Ownership+and+Publication+of+ezCater+Ruby+Gems) that comes with multiple people having push access with personal RubyGems accounts. Once we know this works we can remove everyone except the ezCater-controlled RubyGems account from the owners list.

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
